### PR TITLE
docs: fix command line argument `--num_cpus` to the correct `--num-cpus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda install bioconda::neofox
 NeoFox can be used from the command line as shown below or programmatically (see [https://neofox.readthedocs.io](https://neofox.readthedocs.io/) for more information).
 
 ````commandline
-neofox --candidate-file/--json-file neoantigens_candidates.tab/neoantigens_candidates.json --patient-data/--patient-data-json patient_data.txt/patient_data.json --output-folder /path/to/out --output-prefix out_prefix [--patient-id] [--with-table] [--with-json] [--num_cpus] [--affinity-threshold]
+neofox --candidate-file/--json-file neoantigens_candidates.tab/neoantigens_candidates.json --patient-data/--patient-data-json patient_data.txt/patient_data.json --output-folder /path/to/out --output-prefix out_prefix [--patient-id] [--with-table] [--with-json] [--num-cpus] [--affinity-threshold]
 ````
 - `--candidate-file`: tab-separated values table with neoantigen candidates represented by long mutated peptide sequences as described [here](#41-neoantigen-candidates-in-tabular-format)
 - `--json-file`: JSON file neoantigens in NeoFox model format as  described [here](#42-neoantigen-candidates-in-json-format)
@@ -87,7 +87,7 @@ neofox --candidate-file/--json-file neoantigens_candidates.tab/neoantigens_candi
 - `--output-prefix`: prefix for the output files (*optional*)
 - `--with-table`: output file in tab-separated format (*default*)
 - `--with-json`: output file in JSON format (*optional*)
-- `--num_cpus`: number of CPUs to use (*optional*)
+- `--num-cpus`: number of CPUs to use (*optional*)
 - `--config`: a config file with the paths to dependencies as shown below  (*optional*)
 - `--organism`: the organism to which the data corresponds. Possible values: [human, mouse]. Default value: human
 - `--affinity-threshold`: a affinity value (*optional*) neoantigen candidates with a best predicted affinity greater than or equal than this threshold will be not annotated with features that specifically model

--- a/docs/source/03_03_usage.md
+++ b/docs/source/03_03_usage.md
@@ -14,7 +14,7 @@ neofox --input-file neoantigens_candidates.tsv \
     [--organism human|mouse]  \
     [--rank-mhci-threshold 2.0] \
     [--rank-mhcii-threshold 4.0] \
-    [--num_cpus] \
+    [--num-cpus] \
     [--config] \
     [--patient-id] \
     [--with-all-neoepitopes]
@@ -31,7 +31,7 @@ where:
 - `--rank-mhci-threshold`: MHC-I epitopes with a netMHCpan predicted rank greater than or equal than this threshold will be filtered out (*optional*)
 - `--rank-mhcii-threshold`: MHC-II epitopes with a netMHCIIpan predicted rank greater than or equal than this threshold will be filtered out (*optional*)
 - `--organism`: the organism to which the data corresponds. Possible values: [human, mouse]. Default value: human
-- `--num_cpus`: number of CPUs to use (*optional*)
+- `--num-cpus`: number of CPUs to use (*optional*)
 - `--config`: a config file with the paths to dependencies as shown below  (*optional*)
 - `--patient-id`: patient identifier (*optional*, this is only relevant if the column `patientIdentifier` is missing in the candidate input file)
 
@@ -69,7 +69,7 @@ neofox-epitope --input-file neoepitope_candidates.tsv \
     [--patient-data patient_data.txt \]
     [--output-prefix out_prefix]  \
     [--organism human|mouse]  \
-    [--num_cpus] \
+    [--num-cpus] \
     [--config] \
 ````
 
@@ -80,7 +80,7 @@ where:
 - `--output-folder`: path to the folder to which the output files should be written 
 - `--output-prefix`: prefix for the output files (*optional*)
 - `--organism`: the organism to which the data corresponds. Possible values: [human, mouse]. Default value: human
-- `--num_cpus`: number of CPUs to use (*optional*)
+- `--num-cpus`: number of CPUs to use (*optional*)
 - `--config`: a config file with the paths to dependencies as shown below  (*optional*)
 
 ### Running from docker


### PR DESCRIPTION
I'm trying to use NeoFox and just ran into this issue. The docs state the command line argument for the number of threads to use as `--num_cpus`, but the command line interface actually implements them as `--num-cpus`, see these two spots in the code:

* https://github.com/TRON-Bioinformatics/neofox/blob/03bb13d5e311a98e52d41781fae49bddc0150aee/neofox/command_line.py#L119
* https://github.com/TRON-Bioinformatics/neofox/blob/03bb13d5e311a98e52d41781fae49bddc0150aee/neofox/command_line.py#L294

So all this does, is fix the docs. I double-checked and think I have caught all relevant occurrences. All the remaining instances of `num_cpus` are descriptions of the python API, where this is correct.
