### PR TITLE
docs: remove mention of _neoantigen_features.json from docs, as it is not created

### DIFF
--- a/docs/source/03_02_output_data.md
+++ b/docs/source/03_02_output_data.md
@@ -127,8 +127,6 @@ This is a dummy example:
 
 An output file with the suffix "*_neoantigen_candidates_annotated.json*" is created.  
 This file contains neoantigen candidates information in JSON format.  
-Furthermore, a second file with the suffix *"_neoantigen_features.json"* is created.  
-This file contains the annotated neoantigen features in JSON format.  
 The names within the models are described in **TABLE 1**.
 
 This is a dummy example of a "*_neoantigen_candidates.json*" file.  


### PR DESCRIPTION
A quick `grep -r "_neoantigen_features.json" neofox/` in the main directory of the repo on the `develop` branch doesn't give any results. So it seems this file is never created, even when `--with-json` is set. Thus, this PR removes its mention from the docs.