### PR TITLE
docs: mention that a log file with a fixed file name is always appended to

### DIFF
--- a/docs/source/03_02_output_data.md
+++ b/docs/source/03_02_output_data.md
@@ -109,8 +109,8 @@ The following table describes each of the annotations in the output:
 | Hex_alignment_score_MHCI                  | the alignment score by HEX for ` Best_affinity_MHCI_epitope `                                                                                                                                                                                                                                                   | HEX                               |
 | Hex_alignment_score_MHCII                 | the alignment score by HEX for ` Best_affinity_MHCII_epitope`                                                                                                                                                                                                                                                   | HEX                               |
 
-In addition, a log file with the suffix "*_neoantigen_candidates_annotated.log*"
-is always created.
+In addition, all logging output is appended to a log file with the suffix
+"*_neoantigen_candidates_annotated.log*".
 
 ### Tabular format
 

--- a/docs/source/03_02_output_data.md
+++ b/docs/source/03_02_output_data.md
@@ -110,7 +110,8 @@ The following table describes each of the annotations in the output:
 | Hex_alignment_score_MHCII                 | the alignment score by HEX for ` Best_affinity_MHCII_epitope`                                                                                                                                                                                                                                                   | HEX                               |
 
 In addition, all logging output is appended to a log file with the suffix
-"*_neoantigen_candidates_annotated.log*".
+"*<folder>/<prefix>.log*", where the folder is set by `--output-folder` and the
+prefix can be set with `--output-prefix`.
 
 ### Tabular format
 

--- a/docs/source/03_02_output_data.md
+++ b/docs/source/03_02_output_data.md
@@ -109,6 +109,9 @@ The following table describes each of the annotations in the output:
 | Hex_alignment_score_MHCI                  | the alignment score by HEX for ` Best_affinity_MHCI_epitope `                                                                                                                                                                                                                                                   | HEX                               |
 | Hex_alignment_score_MHCII                 | the alignment score by HEX for ` Best_affinity_MHCII_epitope`                                                                                                                                                                                                                                                   | HEX                               |
 
+In addition, a log file with the suffix "*_neoantigen_candidates_annotated.log*"
+is always created.
+
 ### Tabular format
 
 An output table with the suffix "*_neoantigen_candidates_annotated.tsv*" is created.  


### PR DESCRIPTION
This one tripped me up, as we are using our workflow management system (snakemake) to do the logging for us, but I also got these unexpected log files in the results directory. Also, I initially got confused by old error output before I realized that the log file is not cleared before writing new stuff. So it accumulates the logging output of multiple runs with the same data. As a minimal fix, this PR includes this info in the docs.